### PR TITLE
detect url only if it starts with www or https

### DIFF
--- a/packages/svelte-pieces/CHANGELOG.md
+++ b/packages/svelte-pieces/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Warning: `svelte-pieces` does not follow semver as I inadvertently made it version 1.0 too soon.
 
+## 1.0.47
+
+- - `<DetectUrl>` correctly handles URL's found in the middle of strings
+
 ## 1.0.46
 
 - - Update Button external links to include `noopener noreferrer`

--- a/packages/svelte-pieces/package.json
+++ b/packages/svelte-pieces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-pieces",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "description": "Useful Svelte UI pieces for building web apps",
   "type": "module",
   "svelte": "src/lib/index.ts",

--- a/packages/svelte-pieces/src/lib/functions/DetectUrl.svelte
+++ b/packages/svelte-pieces/src/lib/functions/DetectUrl.svelte
@@ -2,7 +2,7 @@
   export let string: string;
 
   function prepareDisplay(s: string) {
-    const urlRegex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
+    const urlRegex = /^(((https?:\/\/)|(www\.))[^\s]+)/g;
     if (urlRegex.test(s)) {
       return s.replace(/https?:\/\//, '');
     } else {
@@ -11,7 +11,7 @@
   }
 
   function prepareHref(s: string) {
-    const urlRegex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
+    const urlRegex = /^(((https?:\/\/)|(www\.))[^\s]+)/g;
     if (urlRegex.test(s)) {
       return s.replace(/^www\./, 'http://');
     } else {

--- a/packages/svelte-pieces/src/lib/functions/DetectUrl.svelte
+++ b/packages/svelte-pieces/src/lib/functions/DetectUrl.svelte
@@ -1,23 +1,6 @@
 <script lang="ts">
+  import { prepareDisplay, prepareHref } from './detectUrl';
   export let string: string;
-
-  function prepareDisplay(s: string) {
-    const urlRegex = /^(((https?:\/\/)|(www\.))[^\s]+)/g;
-    if (urlRegex.test(s)) {
-      return s.replace(/https?:\/\//, '');
-    } else {
-      return s;
-    }
-  }
-
-  function prepareHref(s: string) {
-    const urlRegex = /^(((https?:\/\/)|(www\.))[^\s]+)/g;
-    if (urlRegex.test(s)) {
-      return s.replace(/^www\./, 'http://');
-    } else {
-      return null;
-    }
-  }
 </script>
 
 <slot display={prepareDisplay(string)} href={prepareHref(string)} />

--- a/packages/svelte-pieces/src/lib/functions/detectUrl.ts
+++ b/packages/svelte-pieces/src/lib/functions/detectUrl.ts
@@ -1,0 +1,40 @@
+const urlRegex = /(((https?:\/\/)|(www\.))[^\s>]+)/g;
+
+export function prepareDisplay(s: string) {
+  if (urlRegex.test(s)) {
+    return s.replace(/https?:\/\//, '');
+  } else {
+    return s;
+  }
+}
+
+export function prepareHref(s: string) {
+  const match = s?.match(urlRegex);
+  if (match?.length) {
+    return match[0].replace(/^www\./, 'http://');
+  } else {
+    return null;
+  }
+}
+
+if (import.meta.vitest) {
+  test('prepareHref handles https, http, www', () => {
+    expect(prepareHref("https://google.com")).toMatchInlineSnapshot('"https://google.com"');
+    expect(prepareHref("http://google.com")).toMatchInlineSnapshot('"http://google.com"');
+    expect(prepareHref("www.google.com")).toMatchInlineSnapshot('"http://google.com"');
+  });
+
+  test('prepareHref handles urls inside strings, inside brackets, and returns 1st url if 2 found', () => {
+    expect(prepareHref("Source: <https://creativecommons.org/licenses/by-sa/2.5>, via Wikimedia Commons, http://google.com")).toMatchInlineSnapshot('"https://creativecommons.org/licenses/by-sa/2.5"');
+  });
+
+  test('prepareHref handles no match and undefined', () => {
+    expect(prepareHref("Foo")).toMatchInlineSnapshot('null');
+    expect(prepareHref(undefined)).toMatchInlineSnapshot('null');
+  });
+  
+  test('prepareDisplay handles no match', () => {
+    expect(prepareDisplay("Foo")).toMatchInlineSnapshot('"Foo"');
+    expect(prepareDisplay(undefined)).toMatchInlineSnapshot('undefined');
+  });
+}

--- a/packages/svelte-pieces/src/routes/functions/detectUrl/+page.svx
+++ b/packages/svelte-pieces/src/routes/functions/detectUrl/+page.svx
@@ -10,11 +10,10 @@
   <DetectUrl string="Bob McNary" let:display let:href>
     <Badge {href} target="_blank">{display}</Badge>
   </DetectUrl>
-  <br />
   <DetectUrl string="Google.com" let:display let:href>
     <Badge {href} target="_blank">{display}</Badge>
   </DetectUrl>
-  <DetectUrl string="Image Source: Jacob Bowdoin, CC BY-SA 2.5 <https://creativecommons.org/licenses/by-sa/2.5>, via Wikimedia Commons" let:display let:href>
+  <DetectUrl string="Source: <https://creativecommons.org/licenses/by-sa/2.5>, via Wikimedia Commons" let:display let:href>
     <Badge {href} target="_blank">{display}</Badge>
   </DetectUrl>
 </Story>

--- a/packages/svelte-pieces/src/routes/functions/detectUrl/+page.svx
+++ b/packages/svelte-pieces/src/routes/functions/detectUrl/+page.svx
@@ -14,6 +14,9 @@
   <DetectUrl string="Google.com" let:display let:href>
     <Badge {href} target="_blank">{display}</Badge>
   </DetectUrl>
+  <DetectUrl string="Image Source: Jacob Bowdoin, CC BY-SA 2.5 <https://creativecommons.org/licenses/by-sa/2.5>, via Wikimedia Commons" let:display let:href>
+    <Badge {href} target="_blank">{display}</Badge>
+  </DetectUrl>
 </Story>
 
 <Story name="http://google.com" showCode>


### PR DESCRIPTION
- [x] Lint the project with `pnpm lint`

### Changesets
We found in the LD app that some intended text was treated as an url if that text matches the regex condition, so I think a person only wants a real url if the regex only matches at the beginning.
https://github.com/livingtongues/living-dictionaries/issues/221
- [ ] If your PR makes a change that should be noted in the changelogs, generate a changeset by running `pnpx changeset` and following the prompts.


<a href="https://gitpod.io/#https://github.com/jacob-8/kitbook/pull/7"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

