### PR TITLE
prevent the URLs matches non alphanumeric characters at the end

### DIFF
--- a/packages/svelte-pieces/CHANGELOG.md
+++ b/packages/svelte-pieces/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Warning: `svelte-pieces` does not follow semver as I inadvertently made it version 1.0 too soon.
 
+## 1.0.48
+
+- - `<DetectUrl>` does not include sentence punctuation found at the end of a URL to avoid capturing broken links
+- 
 ## 1.0.47
 
 - - `<DetectUrl>` correctly handles URL's found in the middle of strings

--- a/packages/svelte-pieces/package.json
+++ b/packages/svelte-pieces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-pieces",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "Useful Svelte UI pieces for building web apps",
   "type": "module",
   "svelte": "src/lib/index.ts",

--- a/packages/svelte-pieces/src/lib/functions/detectUrl.ts
+++ b/packages/svelte-pieces/src/lib/functions/detectUrl.ts
@@ -1,4 +1,4 @@
-const urlRegex = /(((https?:\/\/)|(www\.))[^\s>]+)/g;
+const urlRegex = /(((https?:\/\/)|(www\.))[^\s>]+[$\w])/g;
 
 export function prepareDisplay(s: string) {
   if (urlRegex.test(s)) {
@@ -19,22 +19,32 @@ export function prepareHref(s: string) {
 
 if (import.meta.vitest) {
   test('prepareHref handles https, http, www', () => {
-    expect(prepareHref("https://google.com")).toMatchInlineSnapshot('"https://google.com"');
-    expect(prepareHref("http://google.com")).toMatchInlineSnapshot('"http://google.com"');
-    expect(prepareHref("www.google.com")).toMatchInlineSnapshot('"http://google.com"');
+    expect(prepareHref('https://google.com')).toMatchInlineSnapshot('"https://google.com"');
+    expect(prepareHref('http://google.com')).toMatchInlineSnapshot('"http://google.com"');
+    expect(prepareHref('www.google.com')).toMatchInlineSnapshot('"http://google.com"');
   });
 
   test('prepareHref handles urls inside strings, inside brackets, and returns 1st url if 2 found', () => {
-    expect(prepareHref("Source: <https://creativecommons.org/licenses/by-sa/2.5>, via Wikimedia Commons, http://google.com")).toMatchInlineSnapshot('"https://creativecommons.org/licenses/by-sa/2.5"');
+    expect(
+      prepareHref(
+        'Source: <https://creativecommons.org/licenses/by-sa/2.5>, via Wikimedia Commons, http://google.com'
+      )
+    ).toMatchInlineSnapshot('"https://creativecommons.org/licenses/by-sa/2.5"');
+  });
+
+  test('prepareHref avoid non alpahnumeric characters at the end of the url', () => {
+    expect(prepareHref('https://example.com,')).toMatchInlineSnapshot('"https://example.com"');
+    expect(prepareHref('https://example.com/.')).toMatchInlineSnapshot('"https://example.com"');
+    expect(prepareHref('https://example.com.,´')).toMatchInlineSnapshot('"https://example.com"');
   });
 
   test('prepareHref handles no match and undefined', () => {
-    expect(prepareHref("Foo")).toMatchInlineSnapshot('null');
+    expect(prepareHref('Foo')).toMatchInlineSnapshot('null');
     expect(prepareHref(undefined)).toMatchInlineSnapshot('null');
   });
-  
+
   test('prepareDisplay handles no match', () => {
-    expect(prepareDisplay("Foo")).toMatchInlineSnapshot('"Foo"');
+    expect(prepareDisplay('Foo')).toMatchInlineSnapshot('"Foo"');
     expect(prepareDisplay(undefined)).toMatchInlineSnapshot('undefined');
   });
 }

--- a/packages/svelte-pieces/src/lib/functions/detectUrl.ts
+++ b/packages/svelte-pieces/src/lib/functions/detectUrl.ts
@@ -1,4 +1,4 @@
-const urlRegex = /(((https?:\/\/)|(www\.))[^\s>]+[$\w])/g;
+const urlRegex = /(((https?:\/\/)|(www\.))[^\s>]+\w\/?)/g;
 
 export function prepareDisplay(s: string) {
   if (urlRegex.test(s)) {
@@ -18,7 +18,7 @@ export function prepareHref(s: string) {
 }
 
 if (import.meta.vitest) {
-  test('prepareHref handles https, http, www', () => {
+  test('prepareHref finds urls starting with https://, http://, and www.', () => {
     expect(prepareHref('https://google.com')).toMatchInlineSnapshot('"https://google.com"');
     expect(prepareHref('http://google.com')).toMatchInlineSnapshot('"http://google.com"');
     expect(prepareHref('www.google.com')).toMatchInlineSnapshot('"http://google.com"');
@@ -32,10 +32,10 @@ if (import.meta.vitest) {
     ).toMatchInlineSnapshot('"https://creativecommons.org/licenses/by-sa/2.5"');
   });
 
-  test('prepareHref avoid non alpahnumeric characters at the end of the url', () => {
-    expect(prepareHref('https://example.com,')).toMatchInlineSnapshot('"https://example.com"');
-    expect(prepareHref('https://example.com/.')).toMatchInlineSnapshot('"https://example.com"');
-    expect(prepareHref('https://example.com.,´')).toMatchInlineSnapshot('"https://example.com"');
+  test('prepareHref does not capture non alpahnumeric characters at the end of the url except slash (avoids punctuation)', () => {
+    expect(prepareHref('Here is a good site, https://example.com, and you should vist.')).toMatchInlineSnapshot('"https://example.com"');
+    expect(prepareHref('How does this look https://example.com/?')).toMatchInlineSnapshot('"https://example.com/"');
+    expect(prepareHref('https://example.com.,?')).toMatchInlineSnapshot('"https://example.com"');
   });
 
   test('prepareHref handles no match and undefined', () => {


### PR DESCRIPTION
- [x] Lint the project with `pnpm lint`

### Changesets
Regarding the Living Dictionaries app, users are very likely to put commas, periods, or other non-alphanumeric characters at the end, especially in embedded URLs. So it would be good to avoid selecting those characters.
- [ ] If your PR makes a change that should be noted in the changelogs, generate a changeset by running `pnpx changeset` and following the prompts.


<a href="https://gitpod.io/#https://github.com/jacob-8/kitbook/pull/8"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

